### PR TITLE
Switch away from deprecated v3 of the upload action.

### DIFF
--- a/.github/workflows/generate-esmf-summaries.yml
+++ b/.github/workflows/generate-esmf-summaries.yml
@@ -36,14 +36,14 @@ jobs:
         df -h
     
     - name: Checkout summarizer scripts
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: esmf-org/esmf-test-scripts
         path: esmf-test-scripts
         ref: main
     
     - name: Restore summarizer database
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: summarizer-db
         key: summarizer-db-${{github.run_id}}
@@ -54,14 +54,14 @@ jobs:
         git clone --progress --filter=blob:none https://github.com/esmf-org/esmf-test-artifacts
     
     - name: Checkout ESMF 
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: esmf-org/esmf
         path: esmf   
         fetch-depth: 0
     
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     
@@ -73,7 +73,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     
     - name: Checkout esmf-test-summary
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: esmf-org/esmf-test-summary
         path: esmf-test-summary

--- a/.github/workflows/generate-esmf-summaries.yml
+++ b/.github/workflows/generate-esmf-summaries.yml
@@ -115,7 +115,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: summarizer-db
         path: ${{ github.workspace }}/summarizer-db


### PR DESCRIPTION
As @billsacks said in his PR on the other repositories: 

 The v3 upload-artifact action is deprecated and will be removed in the
future (1/30/2025). This PR updates the action to use v4.

Note possibly breaking changes given in
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md.

I don't think that these apply because I believe the summarizer only runs one instance at a time, but let me know if you think that they do.  Thanks! 